### PR TITLE
Added API endpoints to show use of plug_cors with an api

### DIFF
--- a/lib/sample_phoenix_plug_cors/endpoint.ex
+++ b/lib/sample_phoenix_plug_cors/endpoint.ex
@@ -31,6 +31,6 @@ defmodule SamplePhoenixPlugCors.Endpoint do
     key: "_sample_phoenix_plug_cors_key",
     signing_salt: "PB34Kn91"
 
-  plug PlugCors, origins: ["*"]
+  plug PlugCors, origins: ["fiddle.jshell.net"], methods: ["GET", "PUT"]
   plug :router, SamplePhoenixPlugCors.Router
 end

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -6,4 +6,16 @@ defmodule SamplePhoenixPlugCors.PageController do
   def index(conn, _params) do
     render conn, "index.html"
   end
+
+  def get_user(conn, _params) do
+    render conn, "user.json", %{id: 2}
+  end
+
+  def post_user(conn, _params) do
+    render conn, "user.json", %{id: 2}
+  end
+
+  def put_user(conn, _params) do
+    render conn, "user.json", %{id: 2}
+  end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -20,7 +20,11 @@ defmodule SamplePhoenixPlugCors.Router do
   end
 
   # Other scopes may use custom stacks.
-  # scope "/api", SamplePhoenixPlugCors do
-  #   pipe_through :api
-  # end
+   scope "/api", SamplePhoenixPlugCors do
+     pipe_through :api
+
+     get "/user", PageController, :get_user
+     post "/user", PageController, :post_user
+     put "/user", PageController, :put_user
+   end
 end

--- a/web/views/page_view.ex
+++ b/web/views/page_view.ex
@@ -1,3 +1,7 @@
 defmodule SamplePhoenixPlugCors.PageView do
   use SamplePhoenixPlugCors.Web, :view
+
+  def render("user.json", %{id: id}) do
+    %{id: id}
+  end
 end


### PR DESCRIPTION
This will work in with [this jsfiddle link](http://jsfiddle.net/02fj457x/). Go there, open dev tools in your browser and look at the network link. When you run the fiddle, you should see the OPTIONS request for the CORS info and then the actual request to the api endpoint.
